### PR TITLE
Added a prompt not to add comments in .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The following notebooks, scripts, and modules have been developed for the datase
     Note: try [7zip](https://www.7-zip.org) if decompression errors.
     It might be an [unsupported compression issue](https://github.com/mdeff/fma/issues/5).
 
-1. Fill a `.env` configuration file (at repository's root) with the following content.
+1. Fill a `.env` configuration file (at repository's root) with the following content. Please do not add comments in `.env`.
     ```
     AUDIO_DIR=./data/fma_small/  # the path to a decompressed fma_*.zip
     FMA_KEY=MYKEY  # only if you want to query the freemusicarchive.org API


### PR DESCRIPTION
I added the following to the .env configuration file:

```
AUDIO_DIR=./data/fma_small/  # the path to a decompressed fma_*.zip
FMA_KEY=MYKEY  # only if you want to query the freemusicarchive.org API
```

When I run the 12th unit of `usage.ipynb`, I get an error.

Input:
```python
filename = utils.get_audio_path(AUDIO_DIR, 2)
print('File: {}'.format(filename))

x, sr = librosa.load(filename, sr=None, mono=True)
print('Duration: {:.2f}s, {} samples'.format(x.shape[-1] / sr, x.size))

start, end = 7, 17
ipd.Audio(data=x[start*sr:end*sr], rate=sr)
```

Output:
```
File: ./data/fma_small/  # the path to a decompressed fma_*.zip/000/000002.mp3
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-12-858041869145> in <module>()
      2 print('File: {}'.format(filename))
      3 
----> 4 x, sr = librosa.load(filename, sr=None, mono=True)
      5 print('Duration: {:.2f}s, {} samples'.format(x.shape[-1] / sr, x.size))
      6 

/opt/homebrew/anaconda3/envs/fma/lib/python3.6/site-packages/librosa/core/audio.py in load(path, sr, mono, offset, duration, dtype, res_type)
    105 
    106     y = []
--> 107     with audioread.audio_open(os.path.realpath(path)) as input_file:
    108         sr_native = input_file.samplerate
    109         n_channels = input_file.channels

/opt/homebrew/anaconda3/envs/fma/lib/python3.6/site-packages/audioread/__init__.py in audio_open(path)
     76     from . import rawread
     77     try:
---> 78         return rawread.RawAudioFile(path)
     79     except DecodeError:
     80         pass

/opt/homebrew/anaconda3/envs/fma/lib/python3.6/site-packages/audioread/rawread.py in __init__(self, filename)
     47     """
     48     def __init__(self, filename):
---> 49         self._fh = open(filename, 'rb')
     50 
     51         try:

FileNotFoundError: [Errno 2] No such file or directory: '/Users/zhang/Documents/Repositories.nosync/fma/data/fma_small/  # the path to a decompressed fma_*.zip/000/000002.mp3'
```

This error is because when the environment variable `AUDIO_DIR` is read, its comment (`# the path to a decompressed fma_*.zip`) is also read as part of `AUDIO_DIR`.

I added a prompt at the corresponding position of `README.md`.