### PR TITLE
Deleted redundant `genres_names` definition

### DIFF
--- a/analysis.ipynb
+++ b/analysis.ipynb
@@ -691,7 +691,6 @@
    "source": [
     "enc = MultiLabelBinarizer()\n",
     "genres_indicator = enc.fit_transform(tracks['track', 'genres'])\n",
-    "genres_names = enc.classes_\n",
     "genres_names = genres.loc[enc.classes_, 'title'].values\n",
     "cross_correlation = genres_indicator.T @ genres_indicator"
    ]


### PR DESCRIPTION
In section 4.2 of `analysis.ipynb`, `genres_names` is repeatedly defined:

```python
genres_names = enc.classes_
genres_names = genres.loc[enc.classes_,'title'].values
```

I deleted the upper line.