### PR TITLE
Made the logarithmic image of `cross_correlation` more readable

### DIFF
--- a/analysis.ipynb
+++ b/analysis.ipynb
@@ -693,7 +693,8 @@
     "genres_indicator = enc.fit_transform(tracks['track', 'genres'])\n",
     "genres_names = enc.classes_\n",
     "genres_names = genres.loc[enc.classes_, 'title'].values\n",
-    "cross_correlation = genres_indicator.T @ genres_indicator"
+    "cross_correlation = genres_indicator.T @ genres_indicator\n",
+    "np.fill_diagonal(cross_correlation, 0)"
    ]
   },
   {
@@ -702,11 +703,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.fill_diagonal(cross_correlation, 0)\n",
-    "\n",
     "plt.figure(figsize=(28, 28))\n",
-    "plt.imshow(np.log(cross_correlation))\n",
-    "plt.yticks(range(len(genres_names)), genres_names);\n",
+    "plt.imshow(np.log(cross_correlation[::-1]))\n",
+    "plt.yticks(range(len(genres_names)), genres_names[::-1]);\n",
     "plt.xticks(range(len(genres_names)), genres_names, rotation=90);"
    ]
   },


### PR DESCRIPTION
Before modification, the logarithmic image of `cross_correlation` is as follows:

![cross_correlation_log_old](https://user-images.githubusercontent.com/61679198/123945195-7ab46600-d9d0-11eb-9941-cd5edd590eb3.png)

This drawing method does not conform to our habit of reading an `(X, Y)` image. To make it more readable, I committed this pull request.

After modification, the logarithmic image of `cross_correlation` is as follows:

![cross_correlation_log_new](https://user-images.githubusercontent.com/61679198/123945746-0b8b4180-d9d1-11eb-9e2a-01a654f851de.png)